### PR TITLE
Deprecation warnings with Webpack 4 - use new plugin api

### DIFF
--- a/src/ReactJssHmrPlugin.js
+++ b/src/ReactJssHmrPlugin.js
@@ -19,7 +19,7 @@
  */
 export default class ReactJssHmrPlugin {
   apply(resolver) { // eslint-disable-line class-methods-use-this
-    resolver.plugin('described-resolve', (request, callback) => {
+    resolver.hooks.resolve.tapAsync('described-resolve', (request, resolverContext, callback) => {
       if (process.env.NODE_ENV !== 'production' &&
           request.request === 'react-jss' &&
           request.context &&
@@ -30,9 +30,10 @@ export default class ReactJssHmrPlugin {
           request: 'react-jss-hmr'
         })
         return resolver.doResolve(
-          'resolve',
+          resolver.hooks.resolve,
           aliasedRequest,
           'aliased react-jss to react-jss-hmr',
+          resolverContext,
           callback
         )
       }


### PR DESCRIPTION
Hello, I'm encountering a few deprecation warnings when using this plugin with webpack v4:
`(node:24318) DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead
    at ReactJssHmrPlugin.apply (node_modules/react-jss-hmr/lib/ReactJssHmrPlugin.js:39:16)
...`

`(node:24318) DeprecationWarning: Resolver: The callback argument was splitted into resolveContext and callback.
    at Resolver.doResolve (node_modules/enhanced-resolve/lib/Resolver.js:193:15)
    at Resolver.<anonymous> (node_modules/react-jss-hmr/lib/ReactJssHmrPlugin.js:44:27)
...`

`(node:24318) DeprecationWarning: Resolver#doResolve: The type arguments (string) is now a hook argument (Hook). Pass a reference to the hook instead.
    at Resolver.doResolve (node_modules/enhanced-resolve/lib/Resolver.js:199:11)
    at Resolver.<anonymous> (node_modules/react-jss-hmr/lib/ReactJssHmrPlugin.js:44:27)`

It works fine, since the deprecations won't take full effect until the next major webpack release. However I decided to address these deprecation warnings in this PR.

I just replaced the old `plugin` calls with hooks and new `tap` calls. It seems to pass the required tests:

<img width="700" alt="screen shot 2018-09-24 at 6 24 15 pm" src="https://user-images.githubusercontent.com/23144368/45987567-1d24ab00-c027-11e8-8b50-24aaec7d61ba.png">
